### PR TITLE
rule.subset moved to applyStrategy 

### DIFF
--- a/R/rules.R
+++ b/R/rules.R
@@ -73,7 +73,6 @@
 #' @param timespan an xts/ISO-8601 style \emph{time} subset, like "T08:00/T15:00", see Details
 #' @param store TRUE/FALSE whether to store the strategy in the .strategy environment, or return it.  default FALSE
 #' @param storefun TRUE/FALSE whether to store the function in the rule, default TRUE.  setting this option to FALSE may slow the backtest, but makes \code{\link{debug}} usable
-#' @param rule.subset ISO-8601 subset for period to execute rules over, default NULL
 #' @return if \code{strategy} was the name of a strategy, the name. It it was a strategy, the updated strategy. 
 #' @export
 add.rule <- function(strategy
@@ -262,7 +261,6 @@ enable.rule <- function(strategy, type=c(NULL,"risk","order","rebalance","exit",
 #' @param path.dep TRUE/FALSE whether rule is path dependent, default TRUE, see Details 
 #' @param rule.order default NULL, use at your own risk to adjust order of rule evaluation
 #' @param debug if TRUE, return output list
-#' @param rule.subset ISO-8601 subset for period to execute rules over, default NULL
 #' @seealso \code{\link{add.rule}} \code{\link{applyStrategy}} 
 #' @export
 applyRules <- function(portfolio, 
@@ -275,7 +273,6 @@ applyRules <- function(portfolio,
                         ..., 
                         path.dep=TRUE,
                         rule.order=NULL,
-                        rule.subset=NULL,
                         debug=FALSE) {
     # TODO check for symbol name in mktdata using Josh's code:
     # symbol <- strsplit(colnames(mktdata)[1],"\\.")[[1]][1]
@@ -350,16 +347,7 @@ applyRules <- function(portfolio,
                 }
             }    
         }
-        dindex<-get.dindex()
-              
-        #rule subsetting will decrease the periods we evaluate rules for
-        if(!is.null(rule.subset)){
-          assign.dindex(dindex[which(dindex %in% mktdata[rule.subset,which.i=TRUE])])
-          dindex <- get.dindex()
-          print('included indices:')
-          print(dindex)
-        }
-        
+        dindex<-get.dindex()        
         if(length(dindex)==0) dindex=1 #should this just return?
         
         #for debugging, set dindex to all index values:

--- a/R/strategy.R
+++ b/R/strategy.R
@@ -157,6 +157,8 @@ applyStrategy <- function(strategy,
              }
              mktdata <- get(symbol, envir=envir)
          }
+
+         mktdata <- mktdata[if(is.null(rule.subset)) "/" else rule.subset] # cut mktdata object here based upon rule.subset (avoid dIndex problems)
          
          # loop over indicators
          sret$indicators <- applyIndicators(strategy=strategy, mktdata=mktdata , parameters=parameters, ... )
@@ -194,7 +196,6 @@ applyStrategy <- function(strategy,
                                         parameters=parameters,  
                                         ..., 
                                         path.dep=FALSE,
-                                        rule.subset=rule.subset,
                                         debug=debug)
          
          # Check for open orders
@@ -210,7 +211,6 @@ applyStrategy <- function(strategy,
                                                      parameters=parameters,  
                                                      ..., 
                                                      path.dep=TRUE,
-                                                     rule.subset=rule.subset,
                                                      debug=debug)}
          
          if(isTRUE(initBySymbol)) {


### PR DESCRIPTION
Moves rule.subset inside applyStrategy as opposed to applyRules. Fixes several things:

(1) cleaner & faster: mktdata object is explicitly cut vs dindex lookup and then cut based on indices
(2) rule.subset will return numeric(0) and crash downstream functions if mktdata is NA and dindex cannot find the proper index. Patch fixes this issue. 